### PR TITLE
Alternative data source support (and functional component & hooks rewrite)

### DIFF
--- a/src/cases-graphic-explorer.js
+++ b/src/cases-graphic-explorer.js
@@ -2,20 +2,19 @@ import { ensureBlockMount, exactMountSelector } from '@abcnews/mount-utils';
 import React from 'react';
 import { render } from 'react-dom';
 import CasesGraphicExplorer from './components/CasesGraphicExplorer';
-import { fetchPlacesData } from './utils';
 
-export const renderExplorer = placesData => {
+export const renderExplorer = () => {
   const mountEl = document.querySelector(exactMountSelector('casesgraphicexplorer'));
 
   if (!mountEl) {
     return;
   }
 
-  render(<CasesGraphicExplorer placesData={placesData} />, ensureBlockMount(mountEl));
+  render(<CasesGraphicExplorer />, ensureBlockMount(mountEl));
 };
 
 const domready = fn => {
   /in/.test(document.readyState) ? setTimeout(() => domready(fn), 9) : fn();
 };
 
-fetchPlacesData().then(placesData => domready(() => renderExplorer(placesData)));
+domready(renderExplorer);

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -7,7 +7,7 @@ import DoublingGraphic from '../DoublingGraphic';
 import Placeholder from '../TestComponent';
 import styles from './styles.css';
 
-const App = ({ scrollyData, placesData }) => {
+const App = ({ scrollyData }) => {
   const [preset, setPreset] = useState('initial');
   let maxDate = getInclusiveDateFromYYYYMMDD(scrollyData.panels.length ? scrollyData.panels[0].config.maxdate : '');
 
@@ -24,7 +24,6 @@ const App = ({ scrollyData, placesData }) => {
     Graphic = CasesGraphic;
     graphicProps = {
       ...graphicProps,
-      placesData,
       maxDate
     };
   } else if (graphic === 'doubling') {

--- a/src/components/CasesGraphic/index.js
+++ b/src/components/CasesGraphic/index.js
@@ -16,7 +16,8 @@ import {
   timeFormat
 } from 'd3';
 import { interpolatePath } from 'd3-interpolate-path';
-import React, { Component, createRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { usePlacesData } from '../../data-loader';
 import { KEY_PLACES, KEY_EUROPEAN_PLACES, KEY_TRENDS, TRENDS } from '../../constants';
 import styles from './styles.css';
 
@@ -85,8 +86,8 @@ const UNDERLYING_PROPS_LOWER_LOGARITHMIC_EXTENT_LABELS = {
 };
 export const DEFAULT_CASES_CAP = 5e4; // 50k
 export const DEFAULT_PROPS = {
-  title: null,
-  hasFootnotes: false,
+  title: undefined,
+  hasFootnotes: undefined,
   xScaleType: X_SCALE_TYPES[0],
   yScaleType: Y_SCALE_TYPES[0],
   yScaleProp: Y_SCALE_PROPS[0],
@@ -217,109 +218,136 @@ function setTruncatedLineDashArray(node) {
   node.setAttribute('stroke-dasharray', `${pathLength - 32} 2 6 2 6 2 6 2 6`);
 }
 
+function casesGraphicPlacesData(placesData, maxDate) {
+  return Object.keys(placesData)
+    .map(place => {
+      const placeDates = Object.keys(placesData[place].dates);
+      const population = placesData[place].population || null;
+      let dataAs_dates = placeDates
+        .reduce((memo_dataAs_dates, placeDate, placeDatesIndex) => {
+          const placeDatesTotals = placesData[place].dates[placeDate];
+          const placeDatesTotalsProps = Object.keys(placeDatesTotals);
+          const placeDatesTotalsIncludingPerMillionPeople =
+            typeof population === 'number'
+              ? {
+                  ...placeDatesTotals,
+                  ...placeDatesTotalsProps.reduce((memo_totals, prop) => {
+                    memo_totals[`${prop}pmp`] = (placeDatesTotals[prop] / population) * 1e6;
+
+                    return memo_totals;
+                  }, {})
+                }
+              : placeDatesTotals;
+          const placeDatesTotalsIncludingPerMillionPeopleProps = Object.keys(placeDatesTotalsIncludingPerMillionPeople);
+
+          return memo_dataAs_dates.concat([
+            {
+              date: new Date(placeDate),
+              ...placeDatesTotalsIncludingPerMillionPeople,
+              ...placeDatesTotalsIncludingPerMillionPeopleProps.reduce((memo_totals, prop) => {
+                const newProp = `new${prop}`;
+
+                if (placeDatesIndex === 0) {
+                  memo_totals[newProp] = placeDatesTotalsIncludingPerMillionPeople[prop];
+                } else {
+                  const previousDateTotals = memo_dataAs_dates[memo_dataAs_dates.length - 1];
+
+                  memo_totals[newProp] = Math.max(
+                    0,
+                    placeDatesTotalsIncludingPerMillionPeople[prop] - previousDateTotals[prop]
+                  );
+                }
+
+                return memo_totals;
+              }, {})
+            }
+          ]);
+        }, [])
+        .filter(({ cases, date }) => cases >= 1 && (!maxDate || date <= maxDate)); // should this be filtered on maxDate at render time?
+
+      const dataAs_daysSince100Cases = dataAs_dates
+        .filter(({ cases }) => cases >= 100)
+        .map(({ date, ...otherProps }, index) => ({ day: index, ...otherProps }));
+
+      const dataAs_daysSince1Death = dataAs_dates
+        .filter(({ deaths }) => deaths >= 1)
+        .map(({ date, ...otherProps }, index) => ({ day: index, ...otherProps }));
+
+      const dataAs_daysSince1Recovery = dataAs_dates
+        .filter(({ recoveries }) => recoveries >= 1)
+        .map(({ date, ...otherProps }, index) => ({ day: index, ...otherProps }));
+
+      return {
+        key: place,
+        type: placesData[place].type,
+        population,
+        dataAs: {
+          dates: dataAs_dates,
+          daysSince100Cases: dataAs_daysSince100Cases,
+          daysSince1Death: dataAs_daysSince1Death,
+          daysSince1Recovery: dataAs_daysSince1Recovery
+        },
+        ...Y_SCALE_PROPS.reduce((memo, propName) => {
+          memo[`${propName}Max`] = Math.max.apply(null, [0].concat(dataAs_dates.map(t => t[propName])));
+
+          return memo;
+        }, {})
+      };
+    })
+    .filter(d => d.casesMax >= 100) // Restrict to countries with at least 100 cases
+    .sort((a, b) => b.cases - a.cases);
+}
+
+function usePrevious(value) {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+
+  return ref.current;
+}
+
+const generateRenderId = () => (Math.random() * 0xfffff * 1000000).toString(16).slice(0, 8);
+
 let nextIDIndex = 0;
 
-export default class CasesGraphic extends Component {
-  constructor(props) {
-    super(props);
+const CasesGraphic = props => {
+  const renderId = generateRenderId();
 
-    const { placesData, maxDate, xScaleType, yScaleType } = { ...DEFAULT_PROPS, ...props };
+  const { placesDataURL, maxDate, xScaleType, yScaleType, title, hasFootnotes } = {
+    ...DEFAULT_PROPS,
+    ...props
+  };
 
-    checkScaleTypes(xScaleType, yScaleType);
+  checkScaleTypes(xScaleType, yScaleType);
 
-    this.idIndex = nextIDIndex++;
+  const rootRef = useRef();
+  const titleRef = useRef();
+  const svgRef = useRef();
+  const svgTitleRef = useRef();
+  const svgDescRef = useRef();
+  const footnotesRef = useRef();
+  const [idIndex, svgID, titleID, descID] = useMemo(
+    () => [
+      nextIDIndex,
+      `CasesGraphic${nextIDIndex}SVG`,
+      `CasesGraphic${nextIDIndex}Title`,
+      `CasesGraphic${nextIDIndex++}Desc`
+    ],
+    []
+  );
+  const [
+    { isLoading: isPlacesDataLoading, error: placesDataError, data: commonPlacesData },
+    setPlacesDataURL
+  ] = usePlacesData(placesDataURL);
+  const [placesData, earliestDate, latestDate, numDates] = useMemo(() => {
+    if (!commonPlacesData) {
+      return [];
+    }
 
-    this.rootRef = createRef();
-    this.titleRef = createRef();
-    this.svgRef = createRef();
-    this.svgTitleRef = createRef();
-    this.svgDescRef = createRef();
-    this.footnotesRef = createRef();
-
-    this.measureAndSetDimensions = this.measureAndSetDimensions.bind(this);
-    this.nonOdysseyMeasureAndSetDimensions = this.nonOdysseyMeasureAndSetDimensions.bind(this);
-
-    this.placesData = Object.keys(placesData)
-      .map(place => {
-        const placeDates = Object.keys(placesData[place].dates);
-        const population = placesData[place].population || null;
-        let dataAs_dates = placeDates
-          .reduce((memo_dataAs_dates, placeDate, placeDatesIndex) => {
-            const placeDatesTotals = placesData[place].dates[placeDate];
-            const placeDatesTotalsProps = Object.keys(placeDatesTotals);
-            const placeDatesTotalsIncludingPerMillionPeople =
-              typeof population === 'number'
-                ? {
-                    ...placeDatesTotals,
-                    ...placeDatesTotalsProps.reduce((memo_totals, prop) => {
-                      memo_totals[`${prop}pmp`] = (placeDatesTotals[prop] / population) * 1e6;
-
-                      return memo_totals;
-                    }, {})
-                  }
-                : placeDatesTotals;
-            const placeDatesTotalsIncludingPerMillionPeopleProps = Object.keys(
-              placeDatesTotalsIncludingPerMillionPeople
-            );
-
-            return memo_dataAs_dates.concat([
-              {
-                date: new Date(placeDate),
-                ...placeDatesTotalsIncludingPerMillionPeople,
-                ...placeDatesTotalsIncludingPerMillionPeopleProps.reduce((memo_totals, prop) => {
-                  const newProp = `new${prop}`;
-
-                  if (placeDatesIndex === 0) {
-                    memo_totals[newProp] = placeDatesTotalsIncludingPerMillionPeople[prop];
-                  } else {
-                    const previousDateTotals = memo_dataAs_dates[memo_dataAs_dates.length - 1];
-
-                    memo_totals[newProp] = Math.max(
-                      0,
-                      placeDatesTotalsIncludingPerMillionPeople[prop] - previousDateTotals[prop]
-                    );
-                  }
-
-                  return memo_totals;
-                }, {})
-              }
-            ]);
-          }, [])
-          .filter(({ cases, date }) => cases >= 1 && (!maxDate || date <= maxDate)); // should this be filtered on maxDate at render time?
-
-        const dataAs_daysSince100Cases = dataAs_dates
-          .filter(({ cases }) => cases >= 100)
-          .map(({ date, ...otherProps }, index) => ({ day: index, ...otherProps }));
-
-        const dataAs_daysSince1Death = dataAs_dates
-          .filter(({ deaths }) => deaths >= 1)
-          .map(({ date, ...otherProps }, index) => ({ day: index, ...otherProps }));
-
-        const dataAs_daysSince1Recovery = dataAs_dates
-          .filter(({ recoveries }) => recoveries >= 1)
-          .map(({ date, ...otherProps }, index) => ({ day: index, ...otherProps }));
-
-        return {
-          key: place,
-          type: placesData[place].type,
-          population,
-          dataAs: {
-            dates: dataAs_dates,
-            daysSince100Cases: dataAs_daysSince100Cases,
-            daysSince1Death: dataAs_daysSince1Death,
-            daysSince1Recovery: dataAs_daysSince1Recovery
-          },
-          ...Y_SCALE_PROPS.reduce((memo, propName) => {
-            memo[`${propName}Max`] = Math.max.apply(null, [0].concat(dataAs_dates.map(t => t[propName])));
-
-            return memo;
-          }, {})
-        };
-      })
-      .filter(d => d.casesMax >= 100) // Restrict to countries with at least 100 cases
-      .sort((a, b) => b.cases - a.cases);
-
-    this.earliestDate = this.placesData.reduce((memo, d) => {
+    const placesData = casesGraphicPlacesData(commonPlacesData, maxDate);
+    const earliestDate = placesData.reduce((memo, d) => {
       const candidate = d.dataAs.dates[0].date;
 
       if (candidate < memo) {
@@ -327,8 +355,8 @@ export default class CasesGraphic extends Component {
       }
 
       return memo;
-    }, this.placesData[0].dataAs.dates[0].date);
-    this.latestDate = this.placesData.reduce((memo, d) => {
+    }, placesData[0].dataAs.dates[0].date);
+    const latestDate = placesData.reduce((memo, d) => {
       const candidate = last(d.dataAs.dates).date;
 
       if (candidate > memo) {
@@ -336,48 +364,70 @@ export default class CasesGraphic extends Component {
       }
 
       return memo;
-    }, last(this.placesData[0].dataAs.dates).date);
-    this.numDates = Math.round((this.latestDate - this.earliestDate) / ONE_DAY);
+    }, last(placesData[0].dataAs.dates).date);
+    const numDates = Math.round((latestDate - earliestDate) / ONE_DAY);
 
-    this.state = {
-      width: 0,
-      height: 0
-    };
+    return [placesData, earliestDate, latestDate, numDates];
+  }, [commonPlacesData, maxDate]);
+  const [state, setState] = useState({
+    width: null,
+    height: null,
+    svgHeight: null
+  });
+  const prevProps = usePrevious(props);
+  const prevCommonPlacesData = usePrevious(commonPlacesData);
+  const prevState = usePrevious(state);
+
+  function debug(message) {
+    if (process.env.NODE_ENV === 'development') {
+      console.debug(`[CasesGraphic ${idIndex}:${renderId}] ${message}`);
+    }
   }
 
-  measureAndSetDimensions(client) {
+  function measureAndSetDimensions(client) {
     if (client && !client.hasChanged) {
       return;
     }
 
-    if (!this.rootRef.current) {
+    if (!rootRef.current) {
       return;
     }
 
-    const { width, height } = this.rootRef.current.getBoundingClientRect();
-    const titleRect = this.titleRef.current.getBoundingClientRect();
-    const footnotesRect = this.footnotesRef.current.getBoundingClientRect();
+    const { width, height } = rootRef.current.getBoundingClientRect();
+    const titleRect = titleRef.current.getBoundingClientRect();
+    const footnotesRect = footnotesRef.current.getBoundingClientRect();
 
-    this.setState({ width, height: height - (titleRect.height + footnotesRect.height) });
+    setState({ width, height, svgHeight: height - (titleRect.height + footnotesRect.height) });
   }
 
-  nonOdysseyMeasureAndSetDimensions() {
-    this.measureAndSetDimensions({ hasChanged: true });
+  function nonOdysseyMeasureAndSetDimensions() {
+    measureAndSetDimensions({ hasChanged: true });
   }
 
-  componentDidMount() {
-    this.measureAndSetDimensions();
+  useEffect(() => {
+    measureAndSetDimensions();
 
     if (window.__ODYSSEY__) {
-      window.__ODYSSEY__.scheduler.subscribe(this.measureAndSetDimensions);
+      window.__ODYSSEY__.scheduler.subscribe(measureAndSetDimensions);
     } else {
-      window.addEventListener('resize', this.nonOdysseyMeasureAndSetDimensions);
+      window.addEventListener('resize', nonOdysseyMeasureAndSetDimensions);
     }
-  }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    const prevProps = this.props;
-    const prevState = this.state;
+    return () => {
+      if (window.__ODYSSEY__) {
+        window.__ODYSSEY__.scheduler.unsubscribe(measureAndSetDimensions);
+      } else {
+        window.removeEventListener('resize', nonOdysseyMeasureAndSetDimensions);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!prevProps) {
+      // Dont update on initial render
+      debug('After initial render');
+      return;
+    }
 
     let {
       title,
@@ -394,34 +444,54 @@ export default class CasesGraphic extends Component {
       yScaleProp
     } = {
       ...DEFAULT_PROPS,
-      ...nextProps
+      ...props
     };
-    const { width, height } = nextState;
 
-    const wasResize = width !== prevState.width || height !== prevState.height;
+    if (placesDataURL !== prevProps.placesDataURL) {
+      debug('Places data URL change requires reload');
 
-    if (preset === prevProps.preset && !wasResize) {
-      return false;
+      return setPlacesDataURL(placesDataURL);
+    }
+
+    const { width, height, svgHeight } = state;
+    const wasResize = width !== prevState.width || height !== prevState.height || svgHeight !== prevState.svgHeight;
+
+    if (preset === prevProps.preset && commonPlacesData === prevCommonPlacesData && !wasResize) {
+      debug("No changes to preset or commonPlacesData and wasn't resized");
+      return;
     }
 
     if (title !== prevProps.title || hasFootnotes !== prevProps.hasFootnotes) {
-      setTimeout(() => this.measureAndSetDimensions());
+      debug('Title / footnotes change requires resize');
+      requestAnimationFrame(() => measureAndSetDimensions());
     }
 
-    this.rootRef.current.setAttribute('data-preset', preset);
+    if (isPlacesDataLoading) {
+      debug('Places data is still loading');
+      return;
+    }
+
+    if (placesDataError) {
+      debug(`Error loading places data: ${placesDataError}`);
+      return;
+    }
+
+    debug('Performing standard update');
+
+    rootRef.current.setAttribute('data-preset', preset);
 
     checkScaleTypes(xScaleType, yScaleType);
     checkScaleProps(yScaleProp);
 
     if (typeof places === 'function') {
       // Apply a filter
-      places = this.placesData.filter(places).map(x => x.key);
+      places = placesData.filter(places).map(x => x.key);
     }
 
     // Filter placesData to just visible places, and create visible/highlighted comparison utils
     const isPlaceVisible = inclusionCheckGenerator(places, 'key');
     const isPlaceHighlighted = inclusionCheckGenerator(highlightedPlaces, 'key');
-    const visiblePlacesData = this.placesData.filter(isPlaceVisible);
+    const visiblePlacesData = placesData.filter(isPlaceVisible);
 
     // Only allow trend lines when we are showing cases since 100th case
     if (yScaleProp !== 'cases' || xScaleType !== 'daysSince100Cases') {
@@ -481,9 +551,9 @@ export default class CasesGraphic extends Component {
     const opacityTransitionDuration = wasResize ? 0 : TRANSITION_DURATIONS.opacity;
     const transformTransitionDuration = wasResize ? 0 : TRANSITION_DURATIONS.transform;
     const chartWidth = width - MARGIN.right - MARGIN.left;
-    const chartHeight = height - MARGIN.top - MARGIN.bottom;
+    const chartHeight = svgHeight - MARGIN.top - MARGIN.bottom;
     const xScale = (xScaleType === 'dates'
-      ? scaleTime().domain([new Date(this.earliestDate), new Date(this.latestDate)])
+      ? scaleTime().domain([new Date(earliestDate), new Date(latestDate)])
       : scaleLinear().domain([0, cappedNumDays])
     ).range([0, chartWidth]);
     const yScale = (yScaleType === 'logarithmic'
@@ -536,8 +606,8 @@ export default class CasesGraphic extends Component {
     const isTrendHighlighted = inclusionCheckGenerator(highlightedTrends, 'doublingTimePeriods');
     const visibleTrendsData = generateTrendsData(
       TRENDS.filter(isTrendVisible),
-      this.earliestDate,
-      xScaleType === 'dates' ? this.numDates : cappedNumDays,
+      earliestDate,
+      xScaleType === 'dates' ? numDates : cappedNumDays,
       yScaleCap
     );
     const getAllocatedColor = generateColorAllocator(visiblePlacesData);
@@ -560,20 +630,18 @@ export default class CasesGraphic extends Component {
       .tickFormat('');
 
     // Rendering > 1: Update SVG dimensions
-    const svg = select(this.svgRef.current)
+    const svg = select(svgRef.current)
       .attr('width', width)
-      .attr('height', height);
+      .attr('height', svgHeight);
 
-    // Rendering > 2: Update accessible titles, description & footnotes
-    this.titleRef.current.textContent = title || '';
-    this.svgTitleRef.current.textContent = `${yAxisLabel} on a ${yScaleType} scale.`;
-    this.svgDescRef.current.textContent = visiblePlacesData.length
+    // Rendering > 2: Update accessible SVG title & description
+    svgTitleRef.current.textContent = `${yAxisLabel} on a ${yScaleType} scale.`;
+    svgDescRef.current.textContent = visiblePlacesData.length
       ? `A time-based line chart, plotting ${visiblePlacesData
           .map(x => x.key.replace(/,/g, ''))
           .join(', ')
           .replace(/,(?!.*,)/gim, ' and')} by ${xAxisLabel}.`
       : '';
-    this.footnotesRef.current.innerHTML = hasFootnotes ? FOOTNOTES_MARKUP : '';
 
     // Rendering > 3: Add/update x-axis
     svg
@@ -584,7 +652,7 @@ export default class CasesGraphic extends Component {
     // Rendering > 4: Update x-axis label
     svg
       .select(`.${styles.xAxisLabel}`)
-      .attr('transform', `translate(${MARGIN.left + chartWidth / 2} ${height - REM / 2})`)
+      .attr('transform', `translate(${MARGIN.left + chartWidth / 2} ${svgHeight - REM / 2})`)
       .text(xAxisLabel);
 
     // Rendering > 5: Add/update y-axis
@@ -892,48 +960,36 @@ export default class CasesGraphic extends Component {
       .duration(opacityTransitionDuration)
       .style('fill-opacity', 0)
       .remove();
+  }, [renderId]); // Run every time state/props change
 
-    // Finally, stop React from updating the component (we've managed everything above)
-    return false;
-  }
+  return (
+    <div ref={rootRef} className={styles.root}>
+      <h3 ref={titleRef} className={styles.title}>
+        {title || ''}
+      </h3>
+      <svg ref={svgRef} className={styles.svg} id={svgID} role="img" aria-labelledby={`${titleID} ${descID}`}>
+        <title ref={svgTitleRef} id={titleID} />
+        <desc ref={svgDescRef} id={descID} />
+        <g className={styles.yAxisGridlines} />
+        <g className={styles.trendLines} />
+        <g className={styles.plotLines} />
+        <g className={styles.plotDots} />
+        <g className={styles.xAxis} />
+        <text className={styles.xAxisLabel} />
+        <g className={styles.yAxis} />
+        <text className={styles.yAxisLabel} />
+        <g className={styles.trendLabels} />
+        <g className={styles.plotLabels} />
+      </svg>
+      <p
+        ref={footnotesRef}
+        className={styles.footnotes}
+        dangerouslySetInnerHTML={{ __html: hasFootnotes ? FOOTNOTES_MARKUP : '' }}
+      ></p>
+    </div>
+  );
+};
 
-  componentWillUnmount() {
-    if (window.__ODYSSEY__) {
-      window.__ODYSSEY__.scheduler.unsubscribe(this.measureAndSetDimensions);
-    } else {
-      window.removeEventListener('resize', this.nonOdysseyMeasureAndSetDimensions);
-    }
-  }
+CasesGraphic.displayName = 'CasesGraphic';
 
-  render() {
-    const { title, hasFootnotes } = this.props;
-    const svgID = `CasesGraphic${this.idIndex}SVG`;
-    const titleID = `CasesGraphic${this.idIndex}Title`;
-    const descID = `CasesGraphic${this.idIndex}Desc`;
-
-    return (
-      <div ref={this.rootRef} className={styles.root}>
-        <h3 ref={this.titleRef} className={styles.title}>
-          {title || ''}
-        </h3>
-        <svg ref={this.svgRef} className={styles.svg} id={svgID} role="img" aria-labelledby={`${titleID} ${descID}`}>
-          <title ref={this.svgTitleRef} id={titleID} />
-          <desc ref={this.svgDescRef} id={descID} />
-          <g className={styles.yAxisGridlines} />
-          <g className={styles.trendLines} />
-          <g className={styles.plotLines} />
-          <g className={styles.plotDots} />
-          <g className={styles.xAxis} />
-          <text className={styles.xAxisLabel} />
-          <g className={styles.yAxis} />
-          <text className={styles.yAxisLabel} />
-          <g className={styles.trendLabels} />
-          <g className={styles.plotLabels} />
-        </svg>
-        <p ref={this.footnotesRef} className={styles.footnotes}>
-          {hasFootnotes ? FOOTNOTES_MARKUP : ''}
-        </p>
-      </div>
-    );
-  }
-}
+export default CasesGraphic;

--- a/src/components/CasesGraphic/mounts.js
+++ b/src/components/CasesGraphic/mounts.js
@@ -1,0 +1,4 @@
+import { renderInlineGraphics } from '../../utils';
+import CasesGraphic from '.';
+
+export default () => renderInlineGraphics('casesgraphic', CasesGraphic);

--- a/src/components/TestingGraphic/mounts.js
+++ b/src/components/TestingGraphic/mounts.js
@@ -1,0 +1,4 @@
+import { renderInlineGraphics } from '../../utils';
+import TestingGraphic from '.';
+
+export default () => renderInlineGraphics('testinggraphic', TestingGraphic);

--- a/src/data-loader.js
+++ b/src/data-loader.js
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useReducer, useState } from 'react';
+import { OTHER_PLACES, PLACES_DATA_URL, PLACES_TESTING_DATA_URL, SHIPS } from './constants';
+import COUNTRIES_POPULATIONS from './population';
+
+const PLACE_NAME_REPLACEMENTS = [
+  [/^([A-Z])\w+\s([A-Z])\w+\s([A-Z])\w+$/, '$1$2$3'],
+  [/\sand(\sthe)?\s/, ' & '],
+  [/^East\s/, 'E. '],
+  [/ew\sZealand$/, 'Z'],
+  [/^North\s/, 'N. '],
+  [/^Saint\s/, 'St. '],
+  [/^South\s/, 'S. '],
+  [/^(\w+),\sSouth/, 'S. $1'],
+  [/\*$/, ''],
+  [/nited\s([A-Z])\w+$/, '$1'],
+  [/^West\s/, 'W. ']
+];
+
+const dataFetchReducer = (state, action) => {
+  switch (action.type) {
+    case 'FETCH_INIT':
+      return {
+        ...state,
+        isLoading: true,
+        error: null,
+        data: null
+      };
+    case 'FETCH_SUCCESS':
+      return {
+        ...state,
+        isLoading: false,
+        error: null,
+        data: action.payload
+      };
+    case 'FETCH_FAILURE':
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        data: null
+      };
+    default:
+      throw new Error(`Invalid action type: ${action.type}`);
+  }
+};
+
+const fetchCache = {};
+
+const useDataLoader = initialURL => {
+  const [url, setURL] = useState(initialURL);
+  const [state, dispatch] = useReducer(dataFetchReducer, {
+    isLoading: false,
+    error: null,
+    data: null
+  });
+
+  useEffect(() => {
+    let wasCancelled = false;
+
+    dispatch({ type: 'FETCH_INIT' });
+
+    if (!fetchCache[url]) {
+      fetchCache[url] = fetch(url).then(response => response.json());
+    }
+
+    fetchCache[url]
+      .then(data => {
+        if (!wasCancelled) {
+          dispatch({ type: 'FETCH_SUCCESS', payload: data });
+        }
+      })
+      .catch(error => {
+        if (!wasCancelled) {
+          dispatch({ type: 'FETCH_FAILURE', payload: error });
+        }
+      });
+
+    return () => {
+      wasCancelled = true;
+    };
+  }, [url]);
+
+  return [state, setURL];
+};
+
+export const usePlacesData = initialURL => {
+  const [{ isLoading, error, data: loadedData }, setURL] = useDataLoader(initialURL || PLACES_DATA_URL);
+
+  return [
+    {
+      isLoading,
+      error,
+      data: useMemo(() => {
+        if (loadedData === null) {
+          return null;
+        }
+
+        const data = JSON.parse(JSON.stringify(loadedData));
+
+        Object.keys(data).forEach(key => {
+          let currentPlaceName = key;
+
+          PLACE_NAME_REPLACEMENTS.forEach(pnr => {
+            const [pattern, replacement] = pnr;
+
+            if (pattern.test(currentPlaceName)) {
+              const nextPlaceName = currentPlaceName.replace(pattern, replacement);
+              data[nextPlaceName] = data[currentPlaceName];
+              delete data[currentPlaceName];
+              currentPlaceName = nextPlaceName;
+            }
+          });
+        });
+
+        if (data['Western Sahara']) {
+          delete data['Western Sahara'];
+        }
+
+        // Modify existing data format until we have the new format
+        Object.keys(data).forEach(place => {
+          Object.keys(data[place]).forEach(date => {
+            // Remove last Australian date if it's missing cumulative deaths
+            if (place === 'Australia' && data[place][date].deaths == null) {
+              delete data[place][date];
+              return;
+            }
+
+            data[place][date] = {
+              cases: data[place][date].cases || 0,
+              deaths: data[place][date].deaths || 0,
+              recoveries: data[place][date].recoveries || data[place][date].recovered || 0
+            };
+          });
+
+          data[place] = {
+            type:
+              place === 'Worldwide'
+                ? 'aggregate'
+                : SHIPS.indexOf(place) > -1
+                ? 'ship'
+                : OTHER_PLACES.indexOf(place) > -1
+                ? 'other'
+                : 'country',
+            dates: data[place]
+          };
+
+          if (data[place].type === 'country') {
+            data[place].population = COUNTRIES_POPULATIONS[place];
+          }
+        });
+
+        return data;
+      }, [loadedData])
+    },
+    setURL
+  ];
+};
+
+const supplementaryURLs = {
+  [PLACES_TESTING_DATA_URL]: PLACES_DATA_URL
+};
+
+function getSupplementaryURL(url) {
+  return supplementaryURLs[url.split('?')[0]];
+}
+
+export const usePlacesTestingData = initialURL => {
+  const [{ isLoading, error, data: loadedData }, setPlacesTestingDataURL] = useDataLoader(
+    initialURL || PLACES_TESTING_DATA_URL
+  );
+  const [
+    { isLoading: isSupplementaryLoading, error: supplementaryError, data: supplementaryData },
+    setPlacesDataURL
+  ] = usePlacesData(getSupplementaryURL(initialURL || PLACES_TESTING_DATA_URL));
+
+  return [
+    {
+      isLoading: isSupplementaryLoading || isLoading,
+      error: supplementaryError || error,
+      data: useMemo(() => {
+        if (loadedData == null || supplementaryData == null) {
+          return null;
+        }
+
+        const data = JSON.parse(JSON.stringify(loadedData));
+
+        Object.keys(data).forEach(place => {
+          const supplementaryDataPlace = supplementaryData[place];
+
+          Object.keys(data[place]).forEach(date => {
+            const tests = data[place][date];
+            const supplementaryDataPlaceDate = supplementaryDataPlace.dates[date];
+            const cases = supplementaryDataPlaceDate ? supplementaryDataPlaceDate.cases : 0;
+
+            data[place][date] = {
+              tests,
+              cases,
+              testspcc: cases ? tests / cases : 0
+            };
+          });
+
+          data[place] = {
+            type: supplementaryDataPlace.type,
+            population: supplementaryDataPlace.population,
+            dates: data[place]
+          };
+        });
+
+        return data;
+      }, [loadedData, supplementaryData])
+    },
+    url => {
+      setPlacesTestingDataURL(url || PLACES_TESTING_DATA_URL);
+      setPlacesDataURL(getSupplementaryURL(url || PLACES_TESTING_DATA_URL));
+    }
+  ];
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,9 @@ import { loadScrollyteller } from '@abcnews/scrollyteller';
 import React from 'react';
 import { render } from 'react-dom';
 import App from './components/App';
-import { fetchPlacesData, fetchPlacesTestingData, renderCasesGraphics, renderTestingGraphics } from './utils';
+import renderCasesGraphics from './components/CasesGraphic/mounts';
+import renderTestingGraphics from './components/CasesGraphic/mounts';
 
-const whenPlacesDataFetched = fetchPlacesData();
-const whenPlacesTestingDataFetched = fetchPlacesTestingData();
 const whenOdysseyLoaded = new Promise(resolve =>
   window.__ODYSSEY__
     ? resolve(window.__ODYSSEY__)
@@ -43,16 +42,12 @@ const whenScrollytellersLoaded = new Promise((resolve, reject) =>
   })
 );
 
-function renderAll(scrollyDatas, placesData, placesTestingData) {
-  renderCasesGraphics(placesData);
-  renderTestingGraphics(placesTestingData);
-  scrollyDatas.forEach(scrollyData =>
-    render(<App scrollyData={scrollyData} placesData={placesData} />, scrollyData.mountNode)
-  );
-}
-
 document.documentElement.style.setProperty('--bg', '#f3fcfc');
 
-Promise.all([whenScrollytellersLoaded, whenPlacesDataFetched, whenPlacesTestingDataFetched])
-  .then(results => renderAll.apply(null, results))
+whenScrollytellersLoaded
+  .then(scrollyDatas => {
+    renderCasesGraphics();
+    renderTestingGraphics();
+    scrollyDatas.forEach(scrollyData => render(<App scrollyData={scrollyData} />, scrollyData.mountNode));
+  })
   .catch(console.error);

--- a/src/standalone-cases-graphic.js
+++ b/src/standalone-cases-graphic.js
@@ -1,9 +1,9 @@
 import 'core-js/features/symbol';
 import 'core-js/features/symbol/iterator';
-import { fetchPlacesData, renderCasesGraphics } from './utils';
+import renderCasesGraphics from './components/CasesGraphic/mounts';
 
 const domready = fn => {
   /in/.test(document.readyState) ? setTimeout(() => domready(fn), 9) : fn();
 };
 
-fetchPlacesData().then(placesData => domready(() => renderCasesGraphics(placesData)));
+domready(renderCasesGraphics);

--- a/src/standalone-testing-graphic.js
+++ b/src/standalone-testing-graphic.js
@@ -1,9 +1,9 @@
 import 'core-js/features/symbol';
 import 'core-js/features/symbol/iterator';
-import { fetchPlacesTestingData, renderTestingGraphics } from './utils';
+import renderTestingGraphics from './components/TestingGraphic/mounts';
 
 const domready = fn => {
   /in/.test(document.readyState) ? setTimeout(() => domready(fn), 9) : fn();
 };
 
-fetchPlacesTestingData().then(placesData => domready(() => renderTestingGraphics(placesData)));
+domready(renderTestingGraphics);

--- a/src/testing-graphic-explorer.js
+++ b/src/testing-graphic-explorer.js
@@ -2,7 +2,6 @@ import { ensureBlockMount, exactMountSelector } from '@abcnews/mount-utils';
 import React from 'react';
 import { render } from 'react-dom';
 import TestingGraphicExplorer from './components/TestingGraphicExplorer';
-import { fetchPlacesTestingData } from './utils';
 
 export const renderExplorer = placesData => {
   const mountEl = document.querySelector(exactMountSelector('testinggraphicexplorer'));
@@ -11,11 +10,11 @@ export const renderExplorer = placesData => {
     return;
   }
 
-  render(<TestingGraphicExplorer placesData={placesData} />, ensureBlockMount(mountEl));
+  render(<TestingGraphicExplorer />, ensureBlockMount(mountEl));
 };
 
 const domready = fn => {
   /in/.test(document.readyState) ? setTimeout(() => domready(fn), 9) : fn();
 };
 
-fetchPlacesTestingData().then(placesData => domready(() => renderExplorer(placesData)));
+domready(renderExplorer);

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,11 +9,8 @@ import * as acto from '@abcnews/alternating-case-to-object';
 import { decode, encode } from '@abcnews/base-36-props';
 import React from 'react';
 import { render } from 'react-dom';
-import CasesGraphic from './components/CasesGraphic';
 import InlineGraphic from './components/InlineGraphic';
-import TestingGraphic from './components/TestingGraphic';
-import { OTHER_PLACES, PLACES_DATA_URL, PLACES_TESTING_DATA_URL, PRESETS, SHIPS } from './constants';
-import COUNTRIES_POPULATIONS from './population';
+import { PRESETS } from './constants';
 
 export const encodeVersionedProps = props => encode({ version: process.env.npm_package_version, ...props });
 
@@ -26,113 +23,6 @@ export const decodeVersionedProps = encoded => {
   }
   return decoded;
 };
-
-const CASES_GRAPHIC_MOUNT_PREFIX = 'casesgraphic';
-const TESTING_GRAPHIC_MOUNT_PREFIX = 'testinggraphic';
-const PLACE_NAME_REPLACEMENTS = [
-  [/^([A-Z])\w+\s([A-Z])\w+\s([A-Z])\w+$/, '$1$2$3'],
-  [/\sand(\sthe)?\s/, ' & '],
-  [/^East\s/, 'E. '],
-  [/ew\sZealand$/, 'Z'],
-  [/^North\s/, 'N. '],
-  [/^Saint\s/, 'St. '],
-  [/^South\s/, 'S. '],
-  [/^(\w+),\sSouth/, 'S. $1'],
-  [/\*$/, ''],
-  [/nited\s([A-Z])\w+$/, '$1'],
-  [/^West\s/, 'W. ']
-];
-
-export const fetchPlacesTestingData = () => {
-  return Promise.all([fetch(PLACES_TESTING_DATA_URL).then(response => response.json()), fetchPlacesData()]).then(
-    results => {
-      const [data, supplementaryData] = results;
-
-      Object.keys(data).forEach(place => {
-        const supplementaryDataPlace = supplementaryData[place];
-
-        Object.keys(data[place]).forEach(date => {
-          const tests = data[place][date];
-          const supplementaryDataPlaceDate = supplementaryDataPlace.dates[date];
-          const cases = supplementaryDataPlaceDate ? supplementaryDataPlaceDate.cases : 0;
-
-          data[place][date] = {
-            tests,
-            cases,
-            testspcc: cases ? tests / cases : 0
-          };
-        });
-
-        data[place] = {
-          type: supplementaryDataPlace.type,
-          population: supplementaryDataPlace.population,
-          dates: data[place]
-        };
-      });
-
-      return Promise.resolve(data);
-    }
-  );
-};
-
-export const fetchPlacesData = () =>
-  fetch(PLACES_DATA_URL)
-    .then(response => response.json())
-    .then(data => {
-      Object.keys(data).forEach(key => {
-        let currentPlaceName = key;
-
-        PLACE_NAME_REPLACEMENTS.forEach(pnr => {
-          const [pattern, replacement] = pnr;
-
-          if (pattern.test(currentPlaceName)) {
-            const nextPlaceName = currentPlaceName.replace(pattern, replacement);
-            data[nextPlaceName] = data[currentPlaceName];
-            delete data[currentPlaceName];
-            currentPlaceName = nextPlaceName;
-          }
-        });
-      });
-
-      if (data['Western Sahara']) {
-        delete data['Western Sahara'];
-      }
-
-      // Modify existing data format until we have the new format
-      Object.keys(data).forEach(place => {
-        Object.keys(data[place]).forEach(date => {
-          // Remove last Australian date if it's missing cumulative deaths
-          if (place === 'Australia' && data[place][date].deaths == null) {
-            delete data[place][date];
-            return;
-          }
-
-          data[place][date] = {
-            cases: data[place][date].cases || 0,
-            deaths: data[place][date].deaths || 0,
-            recoveries: data[place][date].recoveries || data[place][date].recovered || 0
-          };
-        });
-
-        data[place] = {
-          type:
-            place === 'Worldwide'
-              ? 'aggregate'
-              : SHIPS.indexOf(place) > -1
-              ? 'ship'
-              : OTHER_PLACES.indexOf(place) > -1
-              ? 'other'
-              : 'country',
-          dates: data[place]
-        };
-
-        if (data[place].type === 'country') {
-          data[place].population = COUNTRIES_POPULATIONS[place];
-        }
-      });
-
-      return Promise.resolve(data);
-    });
 
 export const getInclusiveDateFromYYYYMMDD = yyymmdd => {
   let [, yyyy, mm, dd] = String(yyymmdd).match(/(\d{4})(\d{2})(\d{2})/) || [];
@@ -175,46 +65,17 @@ const prepareMountAndResolveProps = (mountEl, props) => {
   return [presetProp, otherProps];
 };
 
-export const renderCasesGraphics = placesData =>
-  [...document.querySelectorAll(prefixedMountSelector(CASES_GRAPHIC_MOUNT_PREFIX))]
-    .map(ensureBlockMount)
-    .map(mountEl => {
-      const props = acto(getTrailingMountValue(mountEl, CASES_GRAPHIC_MOUNT_PREFIX));
-      const [presetProp, otherProps] = prepareMountAndResolveProps(mountEl, props);
+export const renderInlineGraphics = (mountPrefix, Graphic) =>
+  [...document.querySelectorAll(prefixedMountSelector(mountPrefix))].map(ensureBlockMount).map(mountEl => {
+    const props = acto(getTrailingMountValue(mountEl, mountPrefix));
+    const [presetProp, otherProps] = prepareMountAndResolveProps(mountEl, props);
 
-      render(
-        <InlineGraphic>
-          {otherProps && (
-            <CasesGraphic
-              preset={presetProp}
-              placesData={placesData}
-              maxDate={getInclusiveDateFromYYYYMMDD(props.maxdate)}
-              {...otherProps}
-            />
-          )}
-        </InlineGraphic>,
-        mountEl
-      );
-    });
-
-export const renderTestingGraphics = placesData =>
-  [...document.querySelectorAll(prefixedMountSelector(TESTING_GRAPHIC_MOUNT_PREFIX))]
-    .map(ensureBlockMount)
-    .map(mountEl => {
-      const props = acto(getTrailingMountValue(mountEl, TESTING_GRAPHIC_MOUNT_PREFIX));
-      const [presetProp, otherProps] = prepareMountAndResolveProps(mountEl, props);
-
-      render(
-        <InlineGraphic>
-          {otherProps && (
-            <TestingGraphic
-              preset={presetProp}
-              placesData={placesData}
-              maxDate={getInclusiveDateFromYYYYMMDD(props.maxdate)}
-              {...otherProps}
-            />
-          )}
-        </InlineGraphic>,
-        mountEl
-      );
-    });
+    render(
+      <InlineGraphic>
+        {otherProps && (
+          <Graphic preset={presetProp} maxDate={getInclusiveDateFromYYYYMMDD(props.maxdate)} {...otherProps} />
+        )}
+      </InlineGraphic>,
+      mountEl
+    );
+  });


### PR DESCRIPTION
This enables us to render CasesGraphics and TestingGraphic (including scrolytellers) that fetch places data from more than one endpoint. It currently defaults to the existing endpoints (with data for countries & cruise ships) when nothing is specified.

Changes:

* Convert class & lifecycle event-based CasesGraphic and TestingGraphic components to functional components & hooks.
* Fix CasesGraphic height calculations.
* Refactor utils/mounts so that standalone graphic builds don't include components they'll never render.
* Refactor data fetching into a set of hooks that cache requests/responses.
* Enable alternative places data sources.
* Components now have a placesDataURL prop instead of a placesData prop, so they can load their own data internally (and update it when the endpoint changes).

Also includes WIP for data source selectors in explorers (hidden until we have additional sources published). For now it just appends random query strings to the existing canonical URLs to trigger new fetches & data transforms.