### PR TITLE
Fix bug where some countries had their plot truncated

### DIFF
--- a/src/components/CasesGraphic/index.js
+++ b/src/components/CasesGraphic/index.js
@@ -520,10 +520,6 @@ const CasesGraphic = props => {
                 xDaysUpperExtent = Math.max(xDaysUpperExtent, d[xScaleProp]);
               }
 
-              if (typeof yScaleCap !== 'number') {
-                yUpperExtent = Math.max(yUpperExtent, d[yScaleProp]);
-              }
-
               return d;
             }).length > 0
       )
@@ -548,7 +544,6 @@ const CasesGraphic = props => {
 
         // Update yUpperExtent, taking into account the smoothing provided by the rolling average
         if (typeof yScaleCap !== 'number') {
-          yUpperExtent = 0;
           place.dataAs[xScaleType].map(d => {
             yUpperExtent = Math.max(yUpperExtent, d[yScaleProp]);
           });
@@ -582,15 +577,19 @@ const CasesGraphic = props => {
       d.dataAs[xScaleType].filter(item =>
         xScaleType.indexOf('days') === 0 ? daysCapFilter(item) : timeRangeFilter(item)
       );
-    const getDataCollection = d =>
-      getUncappedYDataCollection(d).filter(
+    const getDataCollection = d =>{
+      const series = getUncappedYDataCollection(d);
+      const filtered = series.filter(
         item => item[yScaleProp] <= yUpperExtent && (yScaleType !== 'logarithmic' || logarithmicLowerExtentFilter(item))
       );
-    const generateLinePath = d =>
-      line()
+      return filtered;
+    }
+    const generateLinePath = d =>{
+      const col = getDataCollection(d);
+      return line()
         .x(d => xScale(d[xScaleProp]))
         .y(d => safe_yScale(d[yScaleProp]))
-        .curve(hasLineSmoothing ? curveMonotoneX : curveLinear)(getDataCollection(d));
+        .curve(hasLineSmoothing ? curveMonotoneX : curveLinear)(getDataCollection(d));}
     const isPlaceYCapped = d =>
       typeof yScaleCap === 'number' && last(getUncappedYDataCollection(d))[yScaleProp] > yScaleCap;
     const generateLinePathLength = d => (isPlaceYCapped(d) ? 100 : 95.5);
@@ -764,7 +763,6 @@ const CasesGraphic = props => {
         if (isPlaceYCapped(d)) {
           setTimeout(setTruncatedLineDashArray, 0, this);
         }
-
         return null;
       })
       .style('stroke-opacity', 0)


### PR DESCRIPTION
The main change is to remove some updates to `yUpperExtent`. Because it was updating in two passes subsequent countries were resetting it to zero.

The other changes are non-functional, but lets you see the filter where the problem was happening.﻿